### PR TITLE
v2.9.0-mobility: Fix Handsontable Read-Only Font Color

### DIFF
--- a/src/web/styles.css
+++ b/src/web/styles.css
@@ -329,6 +329,12 @@ body {
   height: 32px;
 }
 
+/* Override Handsontable read-only cell gray text color (htDimmed) */
+/* Default is #777 gray - change to black for better readability */
+.handsontable td.htDimmed {
+  color: #000 !important;
+}
+
 /* ========================================== */
 /* Patient Presence Indicator (Date Navigator Feature - v1.1.0-mobility) */
 /* ========================================== */


### PR DESCRIPTION
## Summary
- Override Handsontable default gray text (#777) for read-only cells to black (#000)
- Improves readability while keeping cells read-only
- Matches sepsis dashboard font color behavior

## Test plan
- [x] Local testing with simulator mode
- [x] CERT deployment validated (2026-01-13)
- [x] Table text displays as black
- [x] Cells remain read-only (not editable)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)