### PR TITLE
feat: Activity Orders column and message span fix (v2.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.11.0-mobility] - 2026-01-13
+
+### Fixed (Issue #26)
+- **Message Span Fix** - "Select a patient list" message now spans all columns
+  - Updated mergeCells colspan from 8 to 14 (3 locations in main.js)
+
+### Added (Issue #27 - Activity Orders Column)
+- **Activity Column** - Shows active Patient Care orders for patient activity level
+  - Orders: Bedrest (4 types), Up to Chair, Up with Assistance, Ambulate, Out of Bed
+  - Display: Count in cell (80px width, center aligned)
+  - Side Panel: Order list with name, detail, datetime, status
+  - **CCL v15:** Added SELECT 7 for specific activity orders per Tina Stampler
+  - **Source:** Clinician feedback - activity orders show what patient should be doing
+
+### Changed
+- **Column Layout** - Now 14 columns total
+  - Demographics (3): Patient, Unit, Room/Bed
+  - Assessments (3): Baseline, BMAT, Morse
+  - Mobility Activity (6): Activity, Precautions, Toileting, Amb Dist, Transfer Type, Position
+  - PT/OT (2): PT Transfer, OT Transfer
+- **PatientDataService.js** - Added activity_orders MetricTemplate, shifted all column indexes (+1)
+- **main.js** - Added Activity column, updated nestedHeaders (colspan 6), click handler range (3-13)
+- **XMLCclRequestSimulator.js** - Added activity orders mock data (5 orders)
+
+### Technical Notes
+- **Activity vs Precautions:** Activity shows general mobility orders (bedrest, ambulate, etc.); Precautions shows specific restrictions (weight bearing, hip precautions, spine restrictions)
+- **CCL Pattern:** Uses IN clause with 8 specific order names via uar_get_code_by()
+
+---
+
 ## [2.10.0-mobility] - 2026-01-13
 
 ### Added (Issue #24 - Transfer Type & Patient Position Activity)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Project: Mobility Dashboard
 
-**Current Version:** v2.10.0-mobility
+**Current Version:** v2.11.0-mobility
 **Date:** 2026-01-13
 **Project Type:** Healthcare Production ⚠️
 **Enforcement:** Mandatory Workflows Required

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mobility Dashboard
 
-**Version:** v2.10.0-mobility
+**Version:** v2.11.0-mobility
 **Type:** Healthcare Production Dashboard
 **Last Updated:** 2026-01-13
 **Source:** Based on er-tracking-dashboard-template v1.0.0
@@ -9,20 +9,19 @@
 
 ## Current Status
 
-**Latest:** v2.10.0 Transfer Type & Patient Position Activity (Issue #24)
+**Latest:** v2.11.0 Activity Orders Column (Issues #26, #27)
 **Status:** ✅ CERT Validated - Pending Production Deployment
-**Issue:** #24 - Transfer Type & Position Activity
+**Issues:** #26 - Message Span Fix, #27 - Activity Orders Column
 
-**v2.10.0 Changes (2026-01-13):**
-- ✅ Added Transfer Type column (iView documentation)
-- ✅ Added Patient Position Activity column (iView documentation)
-- ✅ Reorganized columns under "Mobility Activity" group header
-- ✅ Hidden 5 demographic columns (Age, Gender, Class, Admitted, Status)
-- ✅ CCL v14 with uar_get_code_by pattern for event codes
+**v2.11.0 Changes (2026-01-13):**
+- ✅ Fixed "Select a patient list" message to span all columns (Issue #26)
+- ✅ Added Activity Orders column for patient mobility level (Issue #27)
+- ✅ CCL v15 with specific activity orders per Tina Stampler's list
+- ✅ Activity orders: Bedrest, Bedrest Care, Bedrest w/ BSC, Bedrest w/ BRP, Up to Chair, Up with Assistance, Ambulate, Out of Bed
 - ✅ CERT deployed and validated
 
-**Column Layout (13 columns):**
-| Demographics (3) | Assessments (3) | Mobility Activity (5) | PT/OT (2) |
+**Column Layout (14 columns):**
+| Demographics (3) | Assessments (3) | Mobility Activity (6) | PT/OT (2) |
 
 **CERT Environment:**
 - **URL:** https://ihazurestoragedev.z13.web.core.windows.net/camc-mobility-mpage/src/index.html

--- a/src/ccl/1_cust_mp_mob_get_pdata_15.prg
+++ b/src/ccl/1_cust_mp_mob_get_pdata_15.prg
@@ -1,0 +1,917 @@
+drop program 1_cust_mp_mob_get_pdata go
+create program 1_cust_mp_mob_get_pdata
+
+;===============================================================================
+; Program: 1_cust_mp_mob_get_pdata_15.prg
+; Version: v15
+; Build Date: 2026-01-13
+; Project: Mobility Dashboard v2.11.0-mobility
+; Issue: #27 - Activity Orders Column
+;
+; Features: demographics, patient-list-integration, 30-day-lookback, 14-clinical-events, activity-orders, activity-precautions, historical-arrays, bmat-parsing, baseline-mobility, toileting-method, pt-ot-transfers, ambulation-distance, ambulation-personnel, powerform-discrete-grid, order-detection, powerform-activity-links, transfer-type, position-activity
+;
+; Description: Get patient demographics + 14 clinical events with 30-day historical data
+;              Uses SEVEN SELECT statements: (1) Demographics, (2) Clinical Events, (3) BMAT,
+;              (4) Activity Precautions, (5) PT Transfer, (6) OT Transfer, (7) Activity Orders
+;              Returns BOTH current values (for table) AND 30-day history (for side panel)
+;              Pattern: Clinical Leader Organizer (Cerner standard) + PowerForm Discrete Grid Navigation
+;
+; Changelog v15:
+;   - ADDED: Activity Orders column (Issue #27)
+;   - ADDED: SELECT 7 for specific activity orders per Tina Stampler
+;   - ADDED: activity_order_count and activity_orders[] to record structure
+;   - Orders: Bedrest (4 types), Up to Chair, Up with Assistance, Ambulate, Out of Bed
+;   - Purpose: Show patient activity level orders (bedrest vs ambulatory)
+;   - Based on v14 with Activity Orders enhancement
+;
+; Changelog v14:
+;   - ADDED: Transfer Type as 12th clinical event (Issue #24)
+;   - ADDED: Patient Position Activity as 13th clinical event (Issue #24)
+;   - ADDED: iView documentation events from nursing charting
+;   - Event codes: 21322903.00 (Transfer Type), 279102325.00 (Patient Position Activity)
+;   - Based on v13 with iView clinical event enhancements
+;
+; Changelog v13:
+;   - ADDED: activity_id to PT/OT transfer history arrays (Issue #21)
+;   - ADDED: dcp_forms_activity_id for PowerForm navigation links
+;   - Purpose: Allow clicking PT/OT history entries to open original PowerForm in view mode
+;   - Pattern: PowerFormLauncher.launchPowerForm(personId, encntrId, 0, activityId, 1)
+;   - Based on v12 with PowerForm activity ID tracking
+;
+; Date Filtering:
+;   - 30-day lookback from current date/time (testing: broader window for data entry)
+;   - Uses: cnvtdatetime(curdate - $LOOKBACK_DAYS, 0) pattern (CCL_COMMON_PATTERNS.md)
+;   - Clinical events filtered by event_end_dt_tm >= 30 days ago
+;
+; Clinical Events (Current + 30-Day History):
+;   1. Morse Fall Risk Score (3612336.00)
+;   2. Call Light & Personal Items Within Reach (29672179.00)
+;   3. IV Sites Assessed (45431765.00)
+;   4. SCDs Applied (10288133561.00)
+;   5. Psychosocial and Safety Needs Addressed (29672693.00)
+;   6. BMAT (Brief Mobility Assessment Tool) - Levels 1-4
+;      - BMAT Sit and Shake (9597986177.00)
+;      - BMAT Stretch and Point (9597989063.00)
+;      - BMAT Stand (9597989705.00)
+;      - BMAT Walk (9597990693.00)
+;   7. Baseline Mobility - Levels 1-4
+;      - PowerForm: "Baseline Functional Assessment"
+;      - Event: "Baseline Mobility" (8339925023.00)
+;      - Format: "(Level X) description"
+;      - Example: "(Level 4) No limitation with walking"
+;   8. Toileting Method - Text
+;      - I-View Documentation: "Toileting Offered ADL"
+;      - Event: "Toileting Offered" (279864735.00)
+;      - Format: Comma-separated methods or single value
+;      - Examples: "Bedside commode, Independent, Assisted to BR, Using Bedpan, Using Urinal"
+;                  "Sleeping"
+;
+; BMAT Parsing Logic:
+;   - Query all 4 BMAT test event codes
+;   - Extract mobility level (1-4) from result_val text
+;   - Examples: "Fail - Patient is Mobility Level 3" → 3
+;               "Pass, move on to Mobility Level 4" → 4
+;
+; Record Structure Enhancement:
+;   - Each metric has TWO fields:
+;     * Current value (e.g., morse_score, bmat_level) - for table display
+;     * Historical array (e.g., morse_history[*], bmat_history[*]) - for side panel
+;   - Historical arrays contain ALL entries from past 30 days (DESC order)
+;
+; Changelog v10:
+;   - ADDED: PT Transfer as 9th clinical event (Issue #10)
+;   - ADDED: OT Transfer as 10th clinical event (Issue #11)
+;   - ADDED: PowerForm discrete grid navigation pattern
+;   - ADDED: SELECT 5 for PT "Transfer Bed to and From Chair Rehab" from PT Acute Evaluation
+;   - ADDED: SELECT 6 for OT "Transfer Bed to and From Chair Rehab" from OT Acute Evaluation
+;   - ADDED: SELECT 7 for PT transfer comments (ce_event_note + long_blob)
+;   - ADDED: SELECT 8 for OT transfer comments (ce_event_note + long_blob)
+;   - ADDED: pt_transfer_assist, pt_transfer_comment, pt_transfer_history[] to record structure
+;   - ADDED: ot_transfer_assist, ot_transfer_comment, ot_transfer_history[] to record structure
+;   - ADDED: Tables: dcp_forms_activity, dcp_forms_activity_comp, ce_event_note, long_blob
+;   - ADDED: Comment handling: compression, RTF removal, ocf_blob cleanup
+;   - Pattern: Same event_cd (4348328.00) distinguished by PowerForm name
+;   - Based on v09 with PT/OT PowerForm enhancements
+;
+; Changelog v09:
+;   - ADDED: Toileting Method as 8th clinical event (Issue #9)
+;   - ADDED: Query for "Toileting Offered ADL" from I-View documentation
+;   - ADDED: No parsing needed - store full text from result_val
+;   - ADDED: toileting_method and toileting_history[] to record structure
+;   - ADDED: Event code 279864735.00 to SELECT 2
+;   - Based on v08 with toileting method enhancements
+;
+; Changelog v08:
+;   - ADDED: Baseline Mobility as 7th clinical event (Issue #8)
+;   - ADDED: Query for "Baseline Mobility" event from "Baseline Functional Assessment" PowerForm
+;   - ADDED: Parsing logic to extract level from "(Level X) description" format
+;   - ADDED: baseline_level and baseline_history[] to record structure
+;   - ADDED: Event code 8339925023.00 to SELECT 2
+;   - Based on v07 with baseline mobility enhancements
+;
+; Changelog v07:
+;   - ADDED: Activity Precautions as side panel metric (Issue #7)
+;   - ADDED: SELECT 4 for order detection using UAR_GET_CODE_BY
+;   - Based on v06 with activity precautions
+;===============================================================================
+
+prompt
+	"Output to File/Printer/MINE" = "MINE"
+	, "Encounter IDs" = 0
+	, "Lookback Days" = 30
+
+with OUTDEV, ENCOUNTER_IDS, LOOKBACK_DAYS
+
+; Version tracking constants
+DECLARE PROGRAM_VERSION = vc WITH CONSTANT("v15"), PROTECT
+DECLARE BUILD_DATE = vc WITH CONSTANT("2026-01-13"), PROTECT
+DECLARE PROGRAM_FEATURES = vc WITH CONSTANT("demographics,patient-list-integration,30-day-lookback,14-clinical-events,activity-orders,activity-precautions,historical-arrays,side-panel,bmat-parsing,baseline-mobility,toileting-method,pt-ot-transfers,ambulation-distance,ambulation-personnel,powerform-discrete-grid,order-detection,seven-select,powerform-activity-links,transfer-type,position-activity"), PROTECT
+
+; Record structure - DEMOGRAPHICS + 5 CLINICAL EVENTS (date-filtered)
+free record drec
+record drec(
+	1 patientCnt = i4
+	1 program_version = vc
+	1 program_build_date = vc
+	1 selected_date = vc
+	1 lookback_days = i4
+	1 patients[*]
+		2 person_id = f8
+		2 encntr_id = f8
+		2 person_name = vc
+		2 unit = vc
+		2 roomBed = vc
+		2 age = vc
+		2 gender = vc
+		2 patient_class = vc
+		2 admission_date = vc
+		2 status = vc
+		2 fin = vc
+		2 mrn = vc
+		; Clinical Events - Current Values (for table display)
+		2 morse_score = vc
+		2 morse_event_dt_tm = vc
+		2 call_light_in_reach = vc
+		2 call_light_dt_tm = vc
+		2 iv_sites_assessed = vc
+		2 iv_sites_dt_tm = vc
+		2 scds_applied = vc
+		2 scds_dt_tm = vc
+		2 safety_needs_addressed = vc
+		2 safety_needs_dt_tm = vc
+		2 bmat_level = vc
+		2 bmat_dt_tm = vc
+		; Historical Arrays - 30-Day History (for side panel)
+		2 morse_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		2 call_light_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		2 iv_sites_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		2 scds_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		2 safety_needs_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		2 bmat_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		2 baseline_level = vc
+		2 baseline_dt_tm = vc
+		2 baseline_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		2 toileting_method = vc
+		2 toileting_dt_tm = vc
+		2 toileting_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		; PT Transfer (Issue #10 - PowerForm Discrete Grid)
+		2 pt_transfer_assist = vc
+		2 pt_transfer_dt_tm = vc
+		2 pt_transfer_comment = vc
+		2 pt_transfer_history[*]
+			3 value = vc
+			3 comment = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+			3 activity_id = f8        ; v13: dcp_forms_activity_id for PowerForm link
+		; OT Transfer (Issue #11 - PowerForm Discrete Grid)
+		2 ot_transfer_assist = vc
+		2 ot_transfer_dt_tm = vc
+		2 ot_transfer_comment = vc
+		2 ot_transfer_history[*]
+			3 value = vc
+			3 comment = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+			3 activity_id = f8        ; v13: dcp_forms_activity_id for PowerForm link
+		; Ambulation Distance (Issue #16 - Numeric Clinical Event)
+		; v12: Added performed_by and performed_position for personnel tracking (Issue #20)
+		2 ambulation_distance = vc
+		2 ambulation_dt_tm = vc
+		2 ambulation_performed_by = vc
+		2 ambulation_performed_position = vc
+		2 ambulation_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+			3 performed_by = vc
+			3 performed_position = vc
+		; Activity Orders (Issue #27) - All Patient Care orders EXCEPT precautions
+		2 activity_order_count = i4
+		2 activity_orders[*]
+			3 order_name = vc
+			3 order_detail = vc
+			3 order_dt_tm = dq8
+			3 datetime_display = vc
+			3 order_status = vc
+		; Activity Precautions (Issue #7)
+		2 active_precaution_count = i4
+		2 activity_precautions[*]
+			3 precaution_name = vc
+			3 order_detail = vc
+			3 order_dt_tm = dq8
+			3 datetime_display = vc
+			3 order_status = vc
+		; Transfer Type (Issue #24 - iView Clinical Event)
+		2 transfer_type = vc
+		2 transfer_type_dt_tm = vc
+		2 transfer_type_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+		; Patient Position Activity (Issue #24 - iView Clinical Event)
+		2 position_activity = vc
+		2 position_activity_dt_tm = vc
+		2 position_activity_history[*]
+			3 value = vc
+			3 event_dt_tm = dq8
+			3 datetime_display = vc
+)
+
+; ==============================================================================
+; 30-Day Lookback - Fixed Time Range (No Date Parameter)
+; ==============================================================================
+; Always shows last 30 days from current time (no user-selected date)
+; Historical data always relative to NOW for side panel display
+; Testing: Broader window allows clinicians to chart test data flexibly
+
+;===============================================================================
+; SELECT 1: Get Demographics (FIN, MRN)
+;===============================================================================
+SELECT INTO "NL:"
+FROM
+	encounter e,
+	person p,
+	encntr_alias ea_fin,
+	encntr_alias ea_mrn
+PLAN e
+	WHERE e.encntr_id = $ENCOUNTER_IDS
+	AND e.active_ind = 1
+JOIN p
+	WHERE p.person_id = e.person_id
+	AND p.active_ind = 1
+JOIN ea_fin
+	WHERE ea_fin.encntr_id = outerjoin(e.encntr_id)
+	AND ea_fin.encntr_alias_type_cd = outerjoin(1077.00)  /* FIN */
+	AND ea_fin.active_ind = outerjoin(1)
+	AND ea_fin.end_effective_dt_tm > outerjoin(SYSDATE)
+JOIN ea_mrn
+	WHERE ea_mrn.encntr_id = outerjoin(e.encntr_id)
+	AND ea_mrn.encntr_alias_type_cd = outerjoin(1079.00)  /* MRN */
+	AND ea_mrn.active_ind = outerjoin(1)
+	AND ea_mrn.end_effective_dt_tm > outerjoin(SYSDATE)
+
+HEAD REPORT
+	cnt = 0
+	drec->program_version = PROGRAM_VERSION
+	drec->program_build_date = BUILD_DATE
+	drec->selected_date = format(curdate, "MM/DD/YYYY;;Q")
+	drec->lookback_days = $LOOKBACK_DAYS
+
+DETAIL
+	cnt = cnt + 1
+	stat = alterlist(drec->patients, cnt)
+
+	; Populate demographics
+	drec->patients[cnt].person_id = p.person_id
+	drec->patients[cnt].encntr_id = e.encntr_id
+	drec->patients[cnt].person_name = p.name_full_formatted
+	drec->patients[cnt].unit = uar_get_code_display(e.loc_nurse_unit_cd)
+	drec->patients[cnt].roomBed = build(uar_get_code_display(e.loc_room_cd), "-", uar_get_code_display(e.loc_bed_cd))
+	drec->patients[cnt].age = cnvtstring(cnvtage(p.birth_dt_tm))
+	drec->patients[cnt].gender = uar_get_code_display(p.sex_cd)
+	drec->patients[cnt].patient_class = uar_get_code_display(e.encntr_class_cd)
+	drec->patients[cnt].admission_date = format(e.reg_dt_tm, "MM/DD/YYYY;;Q")
+	drec->patients[cnt].status = uar_get_code_display(e.active_status_cd)
+	drec->patients[cnt].fin = ea_fin.alias
+	drec->patients[cnt].mrn = ea_mrn.alias
+
+FOOT REPORT
+	drec->patientCnt = cnt
+
+WITH NOCOUNTER, TIME = 60
+
+;===============================================================================
+; SELECT 2: Get Clinical Events (Date-Filtered) - DUMMYT Pattern
+;===============================================================================
+SELECT INTO "NL:"
+FROM
+	(DUMMYT D1 WITH SEQ = SIZE(drec->patients, 5))
+	, clinical_event ce
+	, prsnl p
+
+PLAN D1
+	WHERE drec->patientCnt > 0
+
+JOIN ce
+	WHERE ce.encntr_id = drec->patients[d1.seq].encntr_id
+	AND ce.event_cd IN (
+		value(uar_get_code_by("DISPLAY", 72, "Morse Fall Score")),  /* DISPLAY = "Morse Fall Score", DESCRIPTION = "Morse Fall Risk Score" */
+		value(uar_get_code_by("DISPLAY", 72, "Call Light & Personal Items Within Reach")),
+		value(uar_get_code_by("DISPLAY", 72, "IV Sites Assessed")),
+		value(uar_get_code_by("DISPLAY", 72, "SCDs Applied")),
+		value(uar_get_code_by("DISPLAY", 72, "Psychosocial and Safety Needs Addressed")),
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Sit and Shake")),
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Stretch and Point")),
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Stand")),
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Walk")),
+		value(uar_get_code_by("DISPLAY", 72, "Baseline Mobility")),
+		value(uar_get_code_by("DISPLAY", 72, "Toileting Offered ADL")),
+		269481201.00,  /* Ambulation Distance - hardcoded (not unique) */
+		value(uar_get_code_by("DISPLAY", 72, "Transfer Type")),  /* Issue #24 */
+		value(uar_get_code_by("DISPLAY", 72, "Patient Position Activity"))  /* Issue #24 */
+	)
+	AND ce.event_end_dt_tm >= cnvtdatetime(curdate - $LOOKBACK_DAYS, 0)  /* Dynamic lookback period */
+	AND ce.valid_until_dt_tm >= SYSDATE
+	AND ce.result_status_cd = 25.00  /* Auth */
+
+; v12: Join to prsnl table for personnel tracking (Issue #20 - Ambulation performer)
+JOIN p
+	WHERE p.person_id = outerjoin(ce.performed_prsnl_id)
+	AND p.active_ind = outerjoin(1)
+
+ORDER BY ce.encntr_id, ce.event_cd, ce.event_end_dt_tm DESC  /* Most recent first for historical arrays */
+
+HEAD ce.encntr_id
+	; New encounter - reset tracking
+	null
+
+HEAD ce.event_cd
+	; New event type - reset counter (resets for each event_cd)
+	hist_cnt = 0
+	first_entry = 1
+
+DETAIL
+	; Increment counter for each entry
+	hist_cnt = (hist_cnt + 1)
+
+	; Populate historical arrays - ALL entries from past 7 days
+	if(ce.event_cd = 3612336.00)
+		; Morse Fall Risk Score
+		stat = alterlist(drec->patients[d1.seq].morse_history, hist_cnt)
+		drec->patients[d1.seq].morse_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].morse_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].morse_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		; First entry (most recent) = current value for table
+		if(first_entry = 1)
+			drec->patients[d1.seq].morse_score = ce.result_val
+			drec->patients[d1.seq].morse_event_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = 29672179.00)
+		; Call Light & Personal Items Within Reach
+		stat = alterlist(drec->patients[d1.seq].call_light_history, hist_cnt)
+		drec->patients[d1.seq].call_light_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].call_light_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].call_light_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		if(first_entry = 1)
+			drec->patients[d1.seq].call_light_in_reach = ce.result_val
+			drec->patients[d1.seq].call_light_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = 45431765.00)
+		; IV Sites Assessed
+		stat = alterlist(drec->patients[d1.seq].iv_sites_history, hist_cnt)
+		drec->patients[d1.seq].iv_sites_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].iv_sites_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].iv_sites_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		if(first_entry = 1)
+			drec->patients[d1.seq].iv_sites_assessed = ce.result_val
+			drec->patients[d1.seq].iv_sites_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = 10288133561.00)
+		; SCDs Applied
+		stat = alterlist(drec->patients[d1.seq].scds_history, hist_cnt)
+		drec->patients[d1.seq].scds_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].scds_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].scds_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		if(first_entry = 1)
+			drec->patients[d1.seq].scds_applied = ce.result_val
+			drec->patients[d1.seq].scds_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = 29672693.00)
+		; Psychosocial and Safety Needs Addressed
+		stat = alterlist(drec->patients[d1.seq].safety_needs_history, hist_cnt)
+		drec->patients[d1.seq].safety_needs_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].safety_needs_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].safety_needs_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		if(first_entry = 1)
+			drec->patients[d1.seq].safety_needs_addressed = ce.result_val
+			drec->patients[d1.seq].safety_needs_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = value(uar_get_code_by("DISPLAY", 72, "Baseline Mobility")))
+		; Baseline Mobility - PowerForm "Baseline Functional Assessment"
+		; Parse "(Level X) description" format
+		; Example: "(Level 4) No limitation with walking"
+		;
+		; EDGE CASE - PENDING CLINICAL VALIDATION:
+		; Baseline is typically charted once at admission, but edge cases need verification:
+		; - What if charted on wrong patient and corrected?
+		; - What if modified after authentication?
+		; - Should we show only most recent authenticated, or all entries?
+		; Current implementation: Stores ALL entries in 30-day window, shows most recent in table
+		; Action: Validate with clinical team (Courtney Friend, MOT, OTR/L)
+		;
+		stat = alterlist(drec->patients[d1.seq].baseline_history, hist_cnt)
+
+		; Store full text for side panel display
+		drec->patients[d1.seq].baseline_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].baseline_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].baseline_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+
+		; First entry (most recent) = parse level for table display
+		if(first_entry = 1)
+			; Extract level number from "(Level X)" pattern
+			if(findstring("(Level 1)", ce.result_val) > 0)
+				drec->patients[d1.seq].baseline_level = "1"
+			elseif(findstring("(Level 2)", ce.result_val) > 0)
+				drec->patients[d1.seq].baseline_level = "2"
+			elseif(findstring("(Level 3)", ce.result_val) > 0)
+				drec->patients[d1.seq].baseline_level = "3"
+			elseif(findstring("(Level 4)", ce.result_val) > 0)
+				drec->patients[d1.seq].baseline_level = "4"
+			endif
+			drec->patients[d1.seq].baseline_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = value(uar_get_code_by("DISPLAY", 72, "Toileting Offered ADL")))
+		; Toileting Method - I-View Documentation "Toileting Offered ADL"
+		; Store full text (no parsing needed)
+		; Format: Comma-separated methods or single value
+		; Examples: "Bedside commode, Independent, Assisted to BR, Using Bedpan, Using Urinal"
+		;           "Sleeping"
+		stat = alterlist(drec->patients[d1.seq].toileting_history, hist_cnt)
+
+		; Store full text for both table and side panel
+		drec->patients[d1.seq].toileting_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].toileting_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].toileting_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+
+		; First entry (most recent) = current value for table
+		if(first_entry = 1)
+			drec->patients[d1.seq].toileting_method = ce.result_val
+			drec->patients[d1.seq].toileting_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = 269481201.00)  /* Ambulation Distance - hardcoded (not unique) */
+		; Ambulation Distance - Numeric clinical event with units (feet)
+		; Store full text (includes units: "100 ft")
+		; v12: Added personnel tracking (Issue #20 - who documented ambulation)
+		stat = alterlist(drec->patients[d1.seq].ambulation_history, hist_cnt)
+
+		drec->patients[d1.seq].ambulation_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].ambulation_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].ambulation_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		; v12: Store personnel who documented (PT, OT, Nursing, Cardiac Rehab)
+		drec->patients[d1.seq].ambulation_history[hist_cnt].performed_by = p.name_full_formatted
+		drec->patients[d1.seq].ambulation_history[hist_cnt].performed_position = uar_get_code_display(p.position_cd)
+
+		; First entry (most recent) = current value for table
+		if(first_entry = 1)
+			drec->patients[d1.seq].ambulation_distance = ce.result_val
+			drec->patients[d1.seq].ambulation_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			; v12: Current personnel for table display
+			drec->patients[d1.seq].ambulation_performed_by = p.name_full_formatted
+			drec->patients[d1.seq].ambulation_performed_position = uar_get_code_display(p.position_cd)
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = value(uar_get_code_by("DISPLAY", 72, "Transfer Type")))
+		; Transfer Type - iView documentation (Issue #24)
+		; Example: "1 person lift", "2 person lift", etc.
+		stat = alterlist(drec->patients[d1.seq].transfer_type_history, hist_cnt)
+		drec->patients[d1.seq].transfer_type_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].transfer_type_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].transfer_type_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		if(first_entry = 1)
+			drec->patients[d1.seq].transfer_type = ce.result_val
+			drec->patients[d1.seq].transfer_type_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	elseif(ce.event_cd = value(uar_get_code_by("DISPLAY", 72, "Patient Position Activity")))
+		; Patient Position Activity - iView documentation (Issue #24)
+		; Example: "Turn & positioned - left, Log roll"
+		stat = alterlist(drec->patients[d1.seq].position_activity_history, hist_cnt)
+		drec->patients[d1.seq].position_activity_history[hist_cnt].value = ce.result_val
+		drec->patients[d1.seq].position_activity_history[hist_cnt].event_dt_tm = ce.event_end_dt_tm
+		drec->patients[d1.seq].position_activity_history[hist_cnt].datetime_display = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		if(first_entry = 1)
+			drec->patients[d1.seq].position_activity = ce.result_val
+			drec->patients[d1.seq].position_activity_dt_tm = format(ce.event_end_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+			first_entry = 0
+		endif
+
+	endif
+
+FOOT REPORT
+	null
+
+WITH NOCOUNTER, TIME = 60
+
+;===============================================================================
+; SELECT 3: Get BMAT Assessments (Complex Parsing) - DUMMYT Pattern
+;===============================================================================
+; BMAT requires separate query because 4 events must be grouped by session
+; to determine single mobility level per assessment
+SELECT INTO "NL:"
+FROM
+	(DUMMYT D1 WITH SEQ = SIZE(drec->patients, 5))
+	, clinical_event ce
+
+PLAN D1
+	WHERE drec->patientCnt > 0
+
+JOIN ce
+	WHERE ce.encntr_id = drec->patients[d1.seq].encntr_id
+	AND ce.event_cd IN (
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Sit and Shake")),
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Stretch and Point")),
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Stand")),
+		value(uar_get_code_by("DISPLAY", 72, "BMAT Walk"))
+	)
+	AND ce.event_end_dt_tm >= cnvtdatetime(curdate - $LOOKBACK_DAYS, 0)
+	AND ce.valid_until_dt_tm >= SYSDATE
+	AND ce.result_status_cd = 25.00  /* Auth */
+
+ORDER BY ce.encntr_id, ce.event_end_dt_tm DESC, ce.event_cd
+
+HEAD ce.encntr_id
+	; New patient - reset counter
+	bmat_hist_cnt = 0
+
+HEAD ce.event_end_dt_tm
+	; New BMAT assessment session - will determine level at FOOT
+	bmat_level_str = ""
+	session_dt_tm = ce.event_end_dt_tm
+
+DETAIL
+	; Find highest mobility level mentioned across all 4 test events in this session
+	if(findstring("Mobility Level 4", ce.result_val) > 0)
+		bmat_level_str = "4"
+	elseif(findstring("Mobility Level 3", ce.result_val) > 0 AND bmat_level_str < "3")
+		bmat_level_str = "3"
+	elseif(findstring("Mobility Level 2", ce.result_val) > 0 AND bmat_level_str < "2")
+		bmat_level_str = "2"
+	elseif(findstring("Mobility Level 1", ce.result_val) > 0 AND bmat_level_str < "1")
+		bmat_level_str = "1"
+	endif
+
+FOOT ce.event_end_dt_tm
+	; End of assessment session - store ONE entry for this session
+	if(bmat_level_str > "")
+		bmat_hist_cnt = (bmat_hist_cnt + 1)
+		stat = alterlist(drec->patients[d1.seq].bmat_history, bmat_hist_cnt)
+		drec->patients[d1.seq].bmat_history[bmat_hist_cnt].value = bmat_level_str
+		drec->patients[d1.seq].bmat_history[bmat_hist_cnt].event_dt_tm = session_dt_tm
+		drec->patients[d1.seq].bmat_history[bmat_hist_cnt].datetime_display = format(session_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+
+		; First session (most recent) = current value for table
+		if(bmat_hist_cnt = 1)
+			drec->patients[d1.seq].bmat_level = bmat_level_str
+			drec->patients[d1.seq].bmat_dt_tm = format(session_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+		endif
+	endif
+
+FOOT REPORT
+	null
+
+WITH NOCOUNTER, TIME = 60
+
+;===============================================================================
+; SELECT 4: Get Activity Precautions (Order Detection) - DUMMYT Pattern
+;===============================================================================
+; Query active Patient Care orders for activity precautions
+SELECT INTO "NL:"
+FROM
+	(DUMMYT D1 WITH SEQ = SIZE(drec->patients, 5))
+	, orders o
+
+PLAN D1
+	WHERE drec->patientCnt > 0
+
+JOIN o
+	WHERE o.encntr_id = drec->patients[d1.seq].encntr_id
+	AND o.catalog_type_cd = value(uar_get_code_by("DISPLAY", 6000, "Patient Care"))
+	AND o.order_status_cd = 2550.00  /* Ordered */
+	AND o.catalog_cd IN (
+		value(uar_get_code_by("DISPLAY", 200, "Weight Bearing Status, Lower Extremity")),
+		value(uar_get_code_by("DISPLAY", 200, "Weight Bearing Status, Upper Extremity")),
+		value(uar_get_code_by("DISPLAY", 200, "Hip Precautions Anterior Approach")),
+		value(uar_get_code_by("DISPLAY", 200, "Hip Precautions Posterior Approach")),
+		value(uar_get_code_by("DISPLAY", 200, "Thoracolumbar Spine Restrictions")),
+		value(uar_get_code_by("DISPLAY", 200, "Cervical Spine Restrictions")),
+		value(uar_get_code_by("DISPLAY", 200, "Miami J Cervical Collar"))
+		; TODO (Issue #7): Add when ordered in CERT - Code set 200
+		; value(uar_get_code_by("DISPLAY", 200, "TLSO Brace Activity")),
+		; value(uar_get_code_by("DISPLAY", 200, "LSO Brace Activity"))
+	)
+
+ORDER BY o.encntr_id, o.orig_order_dt_tm DESC
+
+HEAD o.encntr_id
+	; New patient - reset counter
+	precaution_cnt = 0
+
+DETAIL
+	; Add each active precaution to array
+	precaution_cnt = (precaution_cnt + 1)
+	stat = alterlist(drec->patients[d1.seq].activity_precautions, precaution_cnt)
+	drec->patients[d1.seq].activity_precautions[precaution_cnt].precaution_name = o.order_mnemonic
+	drec->patients[d1.seq].activity_precautions[precaution_cnt].order_detail = o.clinical_display_line
+	drec->patients[d1.seq].activity_precautions[precaution_cnt].order_dt_tm = o.orig_order_dt_tm
+	drec->patients[d1.seq].activity_precautions[precaution_cnt].datetime_display = format(o.orig_order_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+	drec->patients[d1.seq].activity_precautions[precaution_cnt].order_status = uar_get_code_display(o.order_status_cd)
+
+FOOT o.encntr_id
+	; Store count for table display
+	drec->patients[d1.seq].active_precaution_count = precaution_cnt
+
+FOOT REPORT
+	null
+
+WITH NOCOUNTER, TIME = 60
+
+;===============================================================================
+; SELECT 5: PT Transfer Assist Level (PowerForm Discrete Grid)
+;===============================================================================
+; PowerForm: "PT Acute Evaluation" → Mobility Section → Discrete Grid
+; Event: "Transfer Bed to and From Chair Rehab" (4348328.00)
+; Pattern: dcp_forms_activity → dcp_forms_activity_comp → clinical_event (3 levels)
+;===============================================================================
+SELECT INTO "NL:"
+FROM
+	(DUMMYT D1 WITH SEQ = SIZE(drec->patients, 5))
+	, dcp_forms_activity dfa_pt
+	, dcp_forms_activity_comp dfc_pt
+	, clinical_event c1_pt
+	, clinical_event c2_pt
+	, clinical_event c3_pt
+	, clinical_event c4_pt
+
+PLAN D1
+	WHERE drec->patientCnt > 0
+
+JOIN dfa_pt
+	WHERE dfa_pt.person_id = drec->patients[d1.seq].person_id
+	AND dfa_pt.encntr_id = drec->patients[d1.seq].encntr_id
+	AND dfa_pt.dcp_forms_ref_id = (
+		SELECT dcp_forms_ref_id
+		FROM dcp_forms_ref
+		WHERE description = "PT Acute Evaluation"
+		AND active_ind = 1
+	)
+	AND dfa_pt.active_ind = 1
+	AND dfa_pt.form_status_cd IN (25.00, 34.00, 35.00)  /* Auth, Modified */
+	AND dfa_pt.form_dt_tm >= cnvtdatetime(curdate - $LOOKBACK_DAYS, 0)
+
+JOIN dfc_pt
+	WHERE dfc_pt.dcp_forms_activity_id = dfa_pt.dcp_forms_activity_id
+	AND dfc_pt.component_cd = 10891.00  /* PRIMARY EVENT_ID */
+	AND dfc_pt.parent_entity_name = "CLINICAL_EVENT"
+
+JOIN c1_pt
+	WHERE c1_pt.event_id = dfc_pt.parent_entity_id
+	AND c1_pt.valid_until_dt_tm > SYSDATE
+	AND c1_pt.view_level = 1
+
+JOIN c2_pt
+	WHERE c2_pt.parent_event_id = c1_pt.event_id
+	AND c2_pt.valid_until_dt_tm > SYSDATE
+	AND c2_pt.event_title_text = "Mobility"
+
+JOIN c3_pt
+	WHERE c3_pt.parent_event_id = c2_pt.event_id
+	AND c3_pt.valid_until_dt_tm > SYSDATE
+	AND c3_pt.event_title_text = "Discrete Grid"
+	AND c3_pt.event_cd = 2214520.00  /* Mobility Grid */
+
+JOIN c4_pt
+	WHERE c4_pt.parent_event_id = c3_pt.event_id
+	AND c4_pt.event_cd = 4348328.00  /* Transfer Bed to and From Chair Rehab */
+	AND c4_pt.valid_until_dt_tm > SYSDATE
+	AND c4_pt.view_level = 1
+	AND c4_pt.result_status_cd IN (25, 34, 35)
+
+ORDER BY c4_pt.encntr_id, dfa_pt.form_dt_tm DESC
+
+HEAD c4_pt.encntr_id
+	pt_hist_cnt = 0
+
+DETAIL
+	pt_hist_cnt = pt_hist_cnt + 1
+	stat = alterlist(drec->patients[d1.seq].pt_transfer_history, pt_hist_cnt)
+
+	drec->patients[d1.seq].pt_transfer_history[pt_hist_cnt].value = c4_pt.result_val
+	drec->patients[d1.seq].pt_transfer_history[pt_hist_cnt].event_dt_tm = dfa_pt.form_dt_tm
+	drec->patients[d1.seq].pt_transfer_history[pt_hist_cnt].datetime_display = format(dfa_pt.form_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+	drec->patients[d1.seq].pt_transfer_history[pt_hist_cnt].comment = ""  /* Populated in SELECT 7 */
+	drec->patients[d1.seq].pt_transfer_history[pt_hist_cnt].activity_id = dfa_pt.dcp_forms_activity_id  ; v13: PowerForm link
+
+	; First entry (most recent) = current value for table
+	if (pt_hist_cnt = 1)
+		drec->patients[d1.seq].pt_transfer_assist = c4_pt.result_val
+		drec->patients[d1.seq].pt_transfer_dt_tm = format(dfa_pt.form_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+	endif
+
+FOOT REPORT
+	null
+
+WITH NOCOUNTER, TIME = 60
+
+;===============================================================================
+; SELECT 6: OT Transfer Assist Level (PowerForm Discrete Grid)
+;===============================================================================
+; PowerForm: "OT Acute Evaluation" → Mobility Section → Discrete Grid
+; Same event_cd as PT, distinguished by PowerForm name
+;===============================================================================
+SELECT INTO "NL:"
+FROM
+	(DUMMYT D1 WITH SEQ = SIZE(drec->patients, 5))
+	, dcp_forms_activity dfa_ot
+	, dcp_forms_activity_comp dfc_ot
+	, clinical_event c1_ot
+	, clinical_event c2_ot
+	, clinical_event c3_ot
+	, clinical_event c4_ot
+
+PLAN D1
+	WHERE drec->patientCnt > 0
+
+JOIN dfa_ot
+	WHERE dfa_ot.person_id = drec->patients[d1.seq].person_id
+	AND dfa_ot.encntr_id = drec->patients[d1.seq].encntr_id
+	AND dfa_ot.dcp_forms_ref_id = (
+		SELECT dcp_forms_ref_id
+		FROM dcp_forms_ref
+		WHERE description = "OT Acute Evaluation"
+		AND active_ind = 1
+	)
+	AND dfa_ot.active_ind = 1
+	AND dfa_ot.form_status_cd IN (25.00, 34.00, 35.00)  /* Auth, Modified */
+	AND dfa_ot.form_dt_tm >= cnvtdatetime(curdate - $LOOKBACK_DAYS, 0)
+
+JOIN dfc_ot
+	WHERE dfc_ot.dcp_forms_activity_id = dfa_ot.dcp_forms_activity_id
+	AND dfc_ot.component_cd = 10891.00  /* PRIMARY EVENT_ID */
+	AND dfc_ot.parent_entity_name = "CLINICAL_EVENT"
+
+JOIN c1_ot
+	WHERE c1_ot.event_id = dfc_ot.parent_entity_id
+	AND c1_ot.valid_until_dt_tm > SYSDATE
+	AND c1_ot.view_level = 1
+
+JOIN c2_ot
+	WHERE c2_ot.parent_event_id = c1_ot.event_id
+	AND c2_ot.valid_until_dt_tm > SYSDATE
+	AND c2_ot.event_title_text = "Mobility"
+
+JOIN c3_ot
+	WHERE c3_ot.parent_event_id = c2_ot.event_id
+	AND c3_ot.valid_until_dt_tm > SYSDATE
+	AND c3_ot.event_title_text = "Discrete Grid"
+	AND c3_ot.event_cd = 2214520.00  /* Mobility Grid */
+
+JOIN c4_ot
+	WHERE c4_ot.parent_event_id = c3_ot.event_id
+	AND c4_ot.event_cd = 4348328.00  /* Transfer Bed to and From Chair Rehab */
+	AND c4_ot.valid_until_dt_tm > SYSDATE
+	AND c4_ot.view_level = 1
+	AND c4_ot.result_status_cd IN (25, 34, 35)
+
+ORDER BY c4_ot.encntr_id, dfa_ot.form_dt_tm DESC
+
+HEAD c4_ot.encntr_id
+	ot_hist_cnt = 0
+
+DETAIL
+	ot_hist_cnt = ot_hist_cnt + 1
+	stat = alterlist(drec->patients[d1.seq].ot_transfer_history, ot_hist_cnt)
+
+	drec->patients[d1.seq].ot_transfer_history[ot_hist_cnt].value = c4_ot.result_val
+	drec->patients[d1.seq].ot_transfer_history[ot_hist_cnt].event_dt_tm = dfa_ot.form_dt_tm
+	drec->patients[d1.seq].ot_transfer_history[ot_hist_cnt].datetime_display = format(dfa_ot.form_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+	drec->patients[d1.seq].ot_transfer_history[ot_hist_cnt].comment = ""  /* Populated in SELECT 8 */
+	drec->patients[d1.seq].ot_transfer_history[ot_hist_cnt].activity_id = dfa_ot.dcp_forms_activity_id  ; v13: PowerForm link
+
+	; First entry (most recent) = current value for table
+	if (ot_hist_cnt = 1)
+		drec->patients[d1.seq].ot_transfer_assist = c4_ot.result_val
+		drec->patients[d1.seq].ot_transfer_dt_tm = format(dfa_ot.form_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+	endif
+
+FOOT REPORT
+	null
+
+WITH NOCOUNTER, TIME = 60
+
+;===============================================================================
+; SELECT 7: Get Activity Orders (Specific Orders per Tina Stampler) - Issue #27
+;===============================================================================
+; Query active Patient Care orders for specific activity types
+; Source: Tina Stampler feedback - bedrest, up to chair, ambulate, out of bed
+SELECT INTO "NL:"
+FROM
+	(DUMMYT D1 WITH SEQ = SIZE(drec->patients, 5))
+	, orders o
+
+PLAN D1
+	WHERE drec->patientCnt > 0
+
+JOIN o
+	WHERE o.encntr_id = drec->patients[d1.seq].encntr_id
+	AND o.catalog_type_cd = value(uar_get_code_by("DISPLAY", 6000, "Patient Care"))
+	AND o.order_status_cd = 2550.00  /* Ordered */
+	AND o.catalog_cd IN (
+		; Bedrest orders (4)
+		value(uar_get_code_by("DISPLAY", 200, "Bedrest")),
+		value(uar_get_code_by("DISPLAY", 200, "Bedrest Care")),
+		value(uar_get_code_by("DISPLAY", 200, "Bedrest w/ Bedside Commode")),
+		value(uar_get_code_by("DISPLAY", 200, "Bedrest with Bathroom Privileges")),
+		; Ambulatory orders (4)
+		value(uar_get_code_by("DISPLAY", 200, "Up to Chair")),
+		value(uar_get_code_by("DISPLAY", 200, "Up with Assistance")),
+		value(uar_get_code_by("DISPLAY", 200, "Ambulate")),
+		value(uar_get_code_by("DISPLAY", 200, "Out of Bed"))
+	)
+
+ORDER BY o.encntr_id, o.orig_order_dt_tm DESC
+
+HEAD o.encntr_id
+	; New patient - reset counter
+	activity_cnt = 0
+
+DETAIL
+	; Add each active order to array
+	activity_cnt = (activity_cnt + 1)
+	stat = alterlist(drec->patients[d1.seq].activity_orders, activity_cnt)
+	drec->patients[d1.seq].activity_orders[activity_cnt].order_name = o.order_mnemonic
+	drec->patients[d1.seq].activity_orders[activity_cnt].order_detail = o.clinical_display_line
+	drec->patients[d1.seq].activity_orders[activity_cnt].order_dt_tm = o.orig_order_dt_tm
+	drec->patients[d1.seq].activity_orders[activity_cnt].datetime_display = format(o.orig_order_dt_tm, "MM/DD/YYYY HH:MM;;Q")
+	drec->patients[d1.seq].activity_orders[activity_cnt].order_status = uar_get_code_display(o.order_status_cd)
+
+FOOT o.encntr_id
+	; Store count for table display
+	drec->patients[d1.seq].activity_order_count = activity_cnt
+
+FOOT REPORT
+	null
+
+WITH NOCOUNTER, TIME = 60
+
+; Output JSON to MPage framework
+SET _memory_reply_string = cnvtrectojson(drec)
+
+; Debug output
+call echo(build("Program Version: ", PROGRAM_VERSION))
+call echo(build("Lookback Period: ", cnvtstring($LOOKBACK_DAYS), " days (", format(cnvtdatetime(curdate - $LOOKBACK_DAYS, 0), "@SHORTDATETIME"), " to ", format(cnvtdatetime(curdate, curtime3), "@SHORTDATETIME"), ")"))
+call echo(build("Patient Count: ", cnvtstring(drec->patientCnt)))
+call echorecord(drec)
+
+end
+go

--- a/src/web/js/Config.js
+++ b/src/web/js/Config.js
@@ -10,9 +10,9 @@
      */
     const simulatorDefault = true; // Simulator mode enabled for local testing
 
-    // Simulator mode ENABLED for local testing (Issue #26 - Message Span Fix)
+    // Simulator mode DISABLED for CERT deployment (Issue #27 - Activity Orders)
     window.SIMULATOR_CONFIG = {
-        enabled: true  // ENABLED - using mock data for local testing
+        enabled: false  // DISABLED - using real CCL programs for CERT testing
     };
 
     console.log(`[Config] SIMULATOR_CONFIG initialized with enabled=${window.SIMULATOR_CONFIG.enabled} (simulator mode - using mock data)`);

--- a/src/web/js/PatientDataService.js
+++ b/src/web/js/PatientDataService.js
@@ -36,13 +36,27 @@
             dataType: 'simple',
             valueField: 'VALUE'
         },
-        // Mobility Activity Group (columns 6-10) - v2.10.0: Reorganized per clinician feedback
+        // Mobility Activity Group (columns 6-11) - v2.11.0: Added Activity Orders (Issue #27)
+        activity_orders: {
+            key: 'activity_orders',
+            label: 'Activity Orders',
+            currentField: 'activity_order_count',
+            historyField: 'activity_orders',
+            columnIndex: 6,
+            dataType: 'complex',
+            fieldMapping: {
+                primary: 'ORDER_NAME',
+                secondary: 'ORDER_DETAIL',
+                datetime: 'DATETIME_DISPLAY',
+                status: 'ORDER_STATUS'
+            }
+        },
         activity_precautions: {
             key: 'activity_precautions',
             label: 'Activity Precautions',
             currentField: 'active_precaution_count',
             historyField: 'activity_precautions',
-            columnIndex: 6,
+            columnIndex: 7,
             dataType: 'complex',
             fieldMapping: {
                 primary: 'PRECAUTION_NAME',
@@ -56,7 +70,7 @@
             label: 'Toileting Method',
             currentField: 'toileting_method',
             historyField: 'toileting_history',
-            columnIndex: 7,
+            columnIndex: 8,
             dataType: 'simple',
             valueField: 'VALUE'
         },
@@ -65,7 +79,7 @@
             label: 'Ambulation Distance',
             currentField: 'ambulation_distance',
             historyField: 'ambulation_history',
-            columnIndex: 8,
+            columnIndex: 9,
             dataType: 'simple',
             valueField: 'VALUE',
             hasPersonnel: true,  // v2.8.0: Shows who documented (PT, OT, Nursing, Cardiac Rehab)
@@ -77,7 +91,7 @@
             label: 'Transfer Type',
             currentField: 'transfer_type',
             historyField: 'transfer_type_history',
-            columnIndex: 9,
+            columnIndex: 10,
             dataType: 'simple',
             valueField: 'VALUE'
         },
@@ -86,17 +100,17 @@
             label: 'Patient Position Activity',
             currentField: 'position_activity',
             historyField: 'position_activity_history',
-            columnIndex: 10,
+            columnIndex: 11,
             dataType: 'simple',
             valueField: 'VALUE'
         },
-        // PT/OT Group (columns 11-12)
+        // PT/OT Group (columns 12-13)
         pt_transfer: {
             key: 'pt_transfer',
             label: 'PT Transfer (Bed to Chair)',
             currentField: 'pt_transfer_assist',
             historyField: 'pt_transfer_history',
-            columnIndex: 11,
+            columnIndex: 12,
             dataType: 'simple',
             valueField: 'VALUE'
         },
@@ -105,7 +119,7 @@
             label: 'OT Transfer (Bed to Chair)',
             currentField: 'ot_transfer_assist',
             historyField: 'ot_transfer_history',
-            columnIndex: 12,
+            columnIndex: 13,
             dataType: 'simple',
             valueField: 'VALUE'
         }
@@ -113,7 +127,7 @@
 
     /**
      * Get metric template by column index
-     * @param {number} columnIndex - Handsontable column index (3-12) - v2.10.0: Shifted after removing 5 demo cols
+     * @param {number} columnIndex - Handsontable column index (3-13) - v2.11.0: Added Activity Orders column
      * @returns {Object|null} Metric template or null if not a metric column
      */
     function getMetricByColumnIndex(columnIndex) {
@@ -383,9 +397,11 @@
                 SCDS_DT_TM: patient.SCDS_DT_TM || patient.scds_dt_tm || '',
                 SAFETY_NEEDS_ADDRESSED: patient.SAFETY_NEEDS_ADDRESSED || patient.safety_needs_addressed || '',
                 SAFETY_NEEDS_DT_TM: patient.SAFETY_NEEDS_DT_TM || patient.safety_needs_dt_tm || '',
+                // Issue #27 - Activity Orders (v2.11.0)
+                ACTIVITY_ORDER_COUNT: patient.ACTIVITY_ORDER_COUNT || patient.activity_order_count || 0,
                 ACTIVE_PRECAUTION_COUNT: patient.ACTIVE_PRECAUTION_COUNT || patient.active_precaution_count || 0,
 
-                // Historical Arrays - 30-Day History for Side Panel (Issue #3, #5, #7, #8, #9, #10, #11)
+                // Historical Arrays - 30-Day History for Side Panel (Issue #3, #5, #7, #8, #9, #10, #11, #27)
                 BMAT_HISTORY: patient.bmat_history || patient.BMAT_HISTORY || [],
                 BASELINE_HISTORY: patient.baseline_history || patient.BASELINE_HISTORY || [],
                 TOILETING_HISTORY: patient.toileting_history || patient.TOILETING_HISTORY || [],
@@ -400,6 +416,8 @@
                 IV_SITES_HISTORY: patient.iv_sites_history || patient.IV_SITES_HISTORY || [],
                 SCDS_HISTORY: patient.scds_history || patient.SCDS_HISTORY || [],
                 SAFETY_NEEDS_HISTORY: patient.safety_needs_history || patient.SAFETY_NEEDS_HISTORY || [],
+                // Issue #27 - Activity Orders (v2.11.0)
+                ACTIVITY_ORDERS: patient.activity_orders || patient.ACTIVITY_ORDERS || [],
                 ACTIVITY_PRECAUTIONS: patient.activity_precautions || patient.ACTIVITY_PRECAUTIONS || []
             };
         });

--- a/src/web/js/XMLCclRequestSimulator.js
+++ b/src/web/js/XMLCclRequestSimulator.js
@@ -777,6 +777,8 @@
             TRANSFER_TYPE_DT_TM: `${nowDisplay} 13:13`,
             POSITION_ACTIVITY: 'Turn & positioned - left, Log roll',
             POSITION_ACTIVITY_DT_TM: `${nowDisplay} 12:59`,
+            // Issue #27 - Activity Orders (v2.11.0)
+            ACTIVITY_ORDER_COUNT: 5,
             ACTIVE_PRECAUTION_COUNT: 7,
             // Historical Arrays - 30-Day History (Issue #3, #5, #7, #8, #9, #10, #11, #16)
             bmat_history: generateHistoricalData.call(this, 3, 2, 6),  // 6 entries: levels 1-4 progression
@@ -876,6 +878,39 @@
                     DATETIME_DISPLAY: `${nowDisplay} 06:00`
                 }
             ],  // Patient positioning (turning/repositioning)
+            // Issue #27 - Activity Orders (v2.11.0)
+            activity_orders: [
+                {
+                    ORDER_NAME: 'Ambulate',
+                    ORDER_DETAIL: `${nowDisplay} 17:37:00 EST, Stop date ${nowDisplay} 17:37:00 EST`,
+                    DATETIME_DISPLAY: `${nowDisplay} 17:36`,
+                    ORDER_STATUS: 'Ordered'
+                },
+                {
+                    ORDER_NAME: 'Bedrest',
+                    ORDER_DETAIL: `${nowDisplay} 17:36:00 EST, Reason: Multiple fractures`,
+                    DATETIME_DISPLAY: `${nowDisplay} 17:36`,
+                    ORDER_STATUS: 'Ordered'
+                },
+                {
+                    ORDER_NAME: 'Up to Chair',
+                    ORDER_DETAIL: `${nowDisplay} 17:37:00 EST, Daily`,
+                    DATETIME_DISPLAY: `${nowDisplay} 17:36`,
+                    ORDER_STATUS: 'Ordered'
+                },
+                {
+                    ORDER_NAME: 'Up with Assistance',
+                    ORDER_DETAIL: `${nowDisplay} 17:37:00 EST`,
+                    DATETIME_DISPLAY: `${nowDisplay} 17:36`,
+                    ORDER_STATUS: 'Ordered'
+                },
+                {
+                    ORDER_NAME: 'Out of Bed',
+                    ORDER_DETAIL: `${nowDisplay} 17:37:00 EST, 3 days, Out of Bed with Assistance`,
+                    DATETIME_DISPLAY: `${nowDisplay} 17:36`,
+                    ORDER_STATUS: 'Ordered'
+                }
+            ],
             activity_precautions: [
                 {
                     PRECAUTION_NAME: 'Weight Bearing Status, Lower Extremity',

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -2489,7 +2489,8 @@
             { data: 'BASELINE_LEVEL', title: 'Baseline', width: 80, className: 'htMiddle htCenter' },
             { data: 'BMAT_LEVEL', title: 'BMAT', width: 70, renderer: bmatLevelRenderer, className: 'htMiddle htCenter' },
             { data: 'MORSE_SCORE', title: 'Morse', width: 80, renderer: morseScoreRenderer, className: 'htMiddle htCenter' },
-            // Mobility Activity Group (5 columns) - v2.10.0: Reorganized per clinician feedback (Issue #24)
+            // Mobility Activity Group (6 columns) - v2.11.0: Added Activity Orders (Issue #27)
+            { data: 'ACTIVITY_ORDER_COUNT', title: 'Activity', width: 80, className: 'htMiddle htCenter' },
             { data: 'ACTIVE_PRECAUTION_COUNT', title: 'Precautions', width: 100, className: 'htMiddle htCenter' },
             { data: 'TOILETING_METHOD', title: 'Toileting', width: 100, className: 'htMiddle htLeft' },
             { data: 'AMBULATION_DISTANCE', title: 'Amb Dist', width: 80, className: 'htMiddle htCenter' },
@@ -2549,7 +2550,7 @@
                 [
                     { label: 'Demographics', colspan: 3 },
                     { label: 'Assessments', colspan: 3 },
-                    { label: 'Mobility Activity', colspan: 5 },
+                    { label: 'Mobility Activity', colspan: 6 },
                     { label: 'PT / OT', colspan: 2 }
                 ],
                 columns.map(col => col.title)  // Column headers as second row
@@ -2663,8 +2664,8 @@
 
             // Clinical Event Click Handler - Side Panel Historical View (Issue #3, #5, #7, #24)
             app.state.handsontableInstance.addHook('afterOnCellMouseDown', function(event, coords, TD) {
-                // Clinical event columns: 3-12 (Baseline, BMAT, Morse, Precautions, Toileting, Amb Dist, Transfer Type, Position, PT, OT) - v2.10.0: Shifted after removing 5 demo cols
-                if (coords.col >= 3 && coords.col <= 12) {
+                // Clinical event columns: 3-13 (Baseline, BMAT, Morse, Activity, Precautions, Toileting, Amb Dist, Transfer Type, Position, PT, OT) - v2.11.0: Added Activity Orders
+                if (coords.col >= 3 && coords.col <= 13) {
                     console.log('Clinical event cell clicked:', { row: coords.row, col: coords.col });
 
                     // Get metric template for this column
@@ -2904,7 +2905,7 @@
                     [
                         { label: 'Demographics', colspan: 3 },
                         { label: 'Assessments', colspan: 3 },
-                        { label: 'Mobility Activity', colspan: 5 },
+                        { label: 'Mobility Activity', colspan: 6 },
                         { label: 'PT / OT', colspan: 2 }
                     ],
                     columns.map(col => col.title)
@@ -3278,7 +3279,7 @@
         // Configure for message display: merge all columns, center text
         if (window.PatientListApp.state.handsontableInstance) {
             window.PatientListApp.state.handsontableInstance.updateSettings({
-                mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 13 }],  // Merge all 13 columns
+                mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 14 }],  // Merge all 13 columns
                 cells: function(row, col) {
                     return {
                         className: 'htCenter htMiddle',  // Center the message
@@ -3311,7 +3312,7 @@
 
             app.state.handsontableInstance.updateSettings({
                 data: messageData,
-                mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 13 }],
+                mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 14 }],
                 cells: function(row, col) {
                     return {
                         className: 'htCenter htMiddle',
@@ -3347,7 +3348,7 @@
             }];
             app.state.handsontableInstance.updateSettings({
                 data: messageData,
-                mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 13 }],  // Merge all columns
+                mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 14 }],  // Merge all columns
                 cells: function(row, col) {
                     return {
                         className: 'htCenter htMiddle',  // Center the message


### PR DESCRIPTION
## Summary
- Fixed "Select a patient list" message to span all 14 columns (Issue #26)
- Added Activity Orders column showing patient mobility level (Issue #27)
- CCL v15 with 8 specific activity orders per Tina Stampler's requirements

## Changes
- **CCL v15**: New SELECT 7 for activity orders (Bedrest, Up to Chair, Ambulate, etc.)
- **PatientDataService.js**: Added activity_orders MetricTemplate, shifted column indexes
- **main.js**: Added Activity column, updated nestedHeaders colspan 5→6, mergeCells 13→14
- **XMLCclRequestSimulator.js**: Mock data for testing

## Test plan
- [x] Local testing with simulator mode
- [x] CERT deployment and validation
- [ ] Production deployment pending

Closes #26
Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)